### PR TITLE
Add optional discord username field

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -71,11 +71,11 @@ body:
     validations:
       required: true
 
-  - type: textarea
+  - type: input
     id: discord-username
     attributes:
       label: Discord Username
-      description: If you are in the [enigmatica discord](https://discord.com/invite/enigmatica) and wouldn't mind being asked further questions there, leave your username here.
+      description: If you are in the [Enigmatica Discord](https://discord.com/invite/enigmatica) and wouldn't mind being asked further questions there, leave your username here.
       placeholder: username#0000
     validations:
       required: false

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -70,3 +70,12 @@ body:
         - 'Both'
     validations:
       required: true
+
+  - type: textarea
+    id: discord-username
+    attributes:
+      label: Discord Username
+      description: If you are in the [enigmatica discord](https://discord.com/invite/enigmatica) and wouldn't mind being asked further questions there, leave your username here.
+      placeholder: username#0000
+    validations:
+      required: false


### PR DESCRIPTION
It is a little bit annoying when an issue isn't clear enough and you'd have to ask further questions, and their username doesn't match with any `@member` in the discord the only option is to go back & forth on discord, which spams `#github` & the inboxes of anyone who has notifications on.

I suggest adding an optional field where people can preemptively leave their discord username so they can be contacted outside of the issue comments.

One example of many where it would have been nice: <https://github.com/EnigmaticaModpacks/Enigmatica6/issues/5097>
![Screen Shot 2022-07-19 at 15 05 47](https://user-images.githubusercontent.com/3179271/179757174-0b01b18f-e284-4eca-a674-305c392a886c.png)

